### PR TITLE
Add setting for round columns, instead of requiring user to uncomment the line that loads them

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Minetest mod "Lapis"
+# "Lapis" Minetest Mod
 
 modified by Napiophelios
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Enable the columns in minetest.conf as follows:
 ```
 enable_round_lapis_columns = true
 ```
-("round" is in the variable name to distinguish the columns from castle masonry's columns which require a lapis mod but are square)
+- setting by Poikilos ("round" is in the variable name to distinguish the columns from castle masonry's columns which require a lapis mod but are square)
+
 
 ------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-===========================
-
-#Minetest mod "Lapis"
+# Minetest mod "Lapis"
 
 modified by Napiophelios
 
@@ -10,7 +8,7 @@ https://forum.minetest.net/viewtopic.php?f=9&t=12368
 
 ![Preview](https://forum.minetest.net/download/file.php?mode=view&id=2780&sid=2afc22e146d22d7b15e6889ac4eeedff)
 
-===========================
+------------------------------------
 
 Enable the columns in minetest.conf as follows:
 ```

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ https://forum.minetest.net/viewtopic.php?f=9&t=12368
 
 Enable the columns in minetest.conf as follows:
 ```
-enable_round_lapis_columns = true
+enable_lapis_mod_columns = true
 ```
-- setting by Poikilos ("round" is in the variable name to distinguish the columns from castle masonry's columns which require a lapis mod but are square)
+- setting by Poikilos: "lapis_mod" is in the variable name to distinguish the columns from castle masonry's columns (which require a lapis mod but are square)
 
 
 ------------------------------------

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ https://forum.minetest.net/viewtopic.php?f=9&t=12368
 
 ![Preview](https://forum.minetest.net/download/file.php?mode=view&id=2780&sid=2afc22e146d22d7b15e6889ac4eeedff)
 
-Usage
-=====
+===========================
 
 Enable the columns in minetest.conf as follows:
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ https://forum.minetest.net/viewtopic.php?f=9&t=12368
 
 ![Preview](https://forum.minetest.net/download/file.php?mode=view&id=2780&sid=2afc22e146d22d7b15e6889ac4eeedff)
 
+Usage
+=====
+
+Enable the columns in minetest.conf as follows:
+```
+enable_round_lapis_columns = true
+```
+("round" is in the variable name to distinguish the columns from castle masonry's columns which require a lapis mod but are square)
+
 ===========================
 
 Lapis Lazuli mod requires

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ enable_round_lapis_columns = true
 ```
 ("round" is in the variable name to distinguish the columns from castle masonry's columns which require a lapis mod but are square)
 
-===========================
+------------------------------------
 
 Lapis Lazuli mod requires
 
@@ -30,7 +30,7 @@ and the development version of Minetest Game 0.4.14
 (commit fa9a345 or later)
 for the new metal sound effects.
 
-===========================
+------------------------------------
 
 This mod adds several decorative nodes
 
@@ -41,7 +41,7 @@ Players can mine Lapis and Pyrite ores;
 craft stairs, slabs, columns, floor tiles, and bricks
 from the ores' drops.
 
-=================================
+------------------------------------
 
 the original Minetest mod:
 
@@ -70,7 +70,7 @@ code refinements by Xanthin
 
 see http://www.gnu.org/licenses/gpl-3.0.html
 
-===================================
+------------------------------------
 
 Textures by Napiophelios
 License: WTFPL
@@ -120,7 +120,7 @@ lapis_pyrite_nugget.png
 
 lapis_pyrite_sacred.png
 
-===================================
+------------------------------------
 
 WTFPL:
 This program is free software. It comes without any warranty, to
@@ -129,7 +129,7 @@ and/or modify it under the terms of the Do What The Fuck You Want
 To Public License, Version 2, as published by Sam Hocevar. See
 http://sam.zoy.org/wtfpl/COPYING for more details.
 
-===================================
+------------------------------------
 
             DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
                     Version 2, December 2004
@@ -145,4 +145,4 @@ http://sam.zoy.org/wtfpl/COPYING for more details.
 
   0. You just DO WHAT THE FUCK YOU WANT TO.
 
-===================================
+------------------------------------

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,8 @@
 screwdriver = screwdriver or {}
 
---dofile(minetest.get_modpath("lapis").."/columns.lua")
+if minetest.settings:get_bool("enable_round_lapis_columns") then
+    dofile(minetest.get_modpath("lapis").."/columns.lua")
+end
 
 ----------
 --Nodes

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,6 @@
 screwdriver = screwdriver or {}
 
-if minetest.settings:get_bool("enable_round_lapis_columns") then
+if minetest.settings:get_bool("enable_lapis_mod_columns") then
     dofile(minetest.get_modpath("lapis").."/columns.lua")
 end
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,4 @@
+#When true, lapis mod's builtin round column nodes and their crafting
+#recipes are available (castle_masonry comes with its own square
+#columns which are always enabled).
+enable_round_lapis_columns (Round Lapis Columns) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,4 +1,4 @@
 #When true, lapis mod's builtin round column nodes and their crafting
 #recipes are available (castle_masonry comes with its own square
 #columns which are always enabled).
-enable_round_lapis_columns (Round Lapis Columns) bool false
+enable_lapis_mod_columns (Lapis Mod Columns) bool false


### PR DESCRIPTION
* add ~~enable_round_lapis_columns~~ enable_lapis_mod_columns (not to be confused with castle masonry's square columns, which require a lapis mod)
* Document the columns feature, which was already present and in the screenshot but not documented.